### PR TITLE
docs: configure mkdocs to generate API reference

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: wafrunner_cli

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 mkdocs
 mkdocs-material
+mkdocstrings[python]


### PR DESCRIPTION
- Add mkdocstrings to requirements-dev.txt
- Create reference.md to host the API reference